### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ torchvision==0.18.1
 numpy==1.26.1
 Pillow
 huggingface_hub
+safetensors
 einops


### PR DESCRIPTION
Required for  `VGGT.from_pretrained("facebook/VGGT-1B")`. huggingface_hub does not pull in this dependency by itself.