### PR TITLE
Switching build system broke installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 # setuptools configuration
-[tool.setuptools]
-packages = ["vggt*"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["vggt*"]
 
 # Pixi configuration
 [tool.pixi.workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ build-backend = "setuptools.build_meta"
 
 # setuptools configuration
 [tool.setuptools]
-packages = ["vggt"]
+packages = ["vggt*"]
 
 # Pixi configuration
 [tool.pixi.workspace]


### PR DESCRIPTION
When things where switched from hatchling -> setuptools, vggt package could not be found when installed.

I fixed this in the pyproject.toml