### PR TITLE
Update uv python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "opencv-python",
 ]
 name = "vggt"
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 version = "0.0.1"
 
 [project.optional-dependencies]


### PR DESCRIPTION
The current python version (3.8) creates a conflict during the installation when using `uv sync` or `uv sync --extra demo`.
```
 The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies
 (e.g., gradio==5.17.1 only supports >=3.10). Consider using a more restrictive `requires-python` value (like >=3.10).
```

This commit fixes the issue by updating to python 3.10 in pyproject.toml.