### PR TITLE
Add MPS backend support

### DIFF
--- a/vggt/heads/utils.py
+++ b/vggt/heads/utils.py
@@ -45,7 +45,7 @@ def make_sincos_pos_embed(embed_dim: int, pos: torch.Tensor, omega_0: float = 10
     - emb: The generated 1D positional embedding.
     """
     assert embed_dim % 2 == 0
-    omega = torch.arange(embed_dim // 2, dtype=torch.double, device=pos.device)
+    omega = torch.arange(embed_dim // 2, dtype=torch.float32, device=pos.device)
     omega /= embed_dim / 2.0
     omega = 1.0 / omega_0**omega  # (D/2,)
 


### PR DESCRIPTION
The current version of the code is not compatible with the MPS backend, mainly due to the dtype of `omega` at `vggt/heads/utils.py` being double. This PR changes it to `torch.float32`. 

I am no sure of the effect this change might have, so if it needs to be `double`, please close this PR.

I did not add it to the PR, for running in the MPS backend it is also necessary to set the environment `PYTORCH_ENABLE_MPS_FALLBACK=1`