### PR TITLE
Fix MPS compatibility by using float32 in positional embeddings

### DIFF
--- a/vggt/heads/utils.py
+++ b/vggt/heads/utils.py
@@ -45,7 +45,8 @@ def make_sincos_pos_embed(embed_dim: int, pos: torch.Tensor, omega_0: float = 10
     - emb: The generated 1D positional embedding.
     """
     assert embed_dim % 2 == 0
-    omega = torch.arange(embed_dim // 2, dtype=torch.double, device=pos.device)
+    device = pos.device
+    omega = torch.arange(embed_dim // 2, dtype=torch.float if device.type == "mps" else torch.double, device=device)
     omega /= embed_dim / 2.0
     omega = 1.0 / omega_0**omega  # (D/2,)
 

--- a/vggt/heads/utils.py
+++ b/vggt/heads/utils.py
@@ -46,7 +46,7 @@ def make_sincos_pos_embed(embed_dim: int, pos: torch.Tensor, omega_0: float = 10
     """
     assert embed_dim % 2 == 0
     device = pos.device
-    omega = torch.arange(embed_dim // 2, dtype=torch.float if device.type == "mps" else torch.double, device=device)
+    omega = torch.arange(embed_dim // 2, dtype=torch.float32 if device.type == "mps" else torch.double, device=device)
     omega /= embed_dim / 2.0
     omega = 1.0 / omega_0**omega  # (D/2,)
 


### PR DESCRIPTION
## Issue:

The MPS backend (Apple Silicon) does not support float64 (double) tensors, causing runtime errors during positional embedding calculations.

## Fix:

Replace `torch.double` with `torch.float32` in make_sincos_pos_embed to ensure float32 usage.

Explicitly enforce float32 dtype consistency across model inputs and positional embeddings.