### PR TITLE
Move numpy to >= 2.0 (numpy 1.* goes end of life in september)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 authors = [{name = "Jianyuan Wang", email = "jianyuan@robots.ox.ac.uk"}]
 dependencies = [
-    "numpy<2",
+    "numpy>=2",
     "Pillow",
     "huggingface_hub",
     "einops",


### PR DESCRIPTION
numpy 1.* reaches eol come september 2025, migrate over to numpy>= 2.0

I tested this out and had no issues when running with cuda 12.8 and pytorch==2.7.0

Let me know if there's a specific reason for staying below 2.0