### PR TITLE
Fix a typo in batch_np_matrix_to_pycolmap

### DIFF
--- a/vggt/dependency/np_to_pycolmap.py
+++ b/vggt/dependency/np_to_pycolmap.py
@@ -51,6 +51,8 @@ def batch_np_matrix_to_pycolmap(
     assert len(points3d) == P
     assert image_size.shape[0] == 2
 
+    reproj_mask = None
+
     if max_reproj_error is not None:
         projected_points_2d, projected_points_cam = project_3D_points_np(points3d, extrinsics, intrinsics)
         projected_diff = np.linalg.norm(projected_points_2d - tracks, axis=-1)


### PR DESCRIPTION
The current implementation can cause `reproj_mask` to be undefined in `batch_np_matrix_to_pycolmap()` if `max_reproj_error = None` causing the following: 

```
if masks is not None and reproj_mask is not None:
UnboundLocalError: local variable 'reproj_mask' referenced before assignment
``` 

Initializing `reproj_mask` beforehand fix that error.