### PR TITLE
Fix CUDA tensor serialization error in predictions saving

### DIFF
--- a/demo_gradio.py
+++ b/demo_gradio.py
@@ -212,6 +212,14 @@ def gradio_demo(
     with torch.no_grad():
         predictions = run_model(target_dir, model)
 
+ 
+    # Convert CUDA tensors to CPU before saving
+    for key, value in predictions.items():
+        if isinstance(value, list):
+            predictions[key] = [item.cpu() if hasattr(item, 'is_cuda') and item.is_cuda else item for item in value]
+        elif hasattr(value, 'is_cuda') and value.is_cuda:
+            predictions[key] = value.cpu()
+
     # Save predictions
     prediction_save_path = os.path.join(target_dir, "predictions.npz")
     np.savez(prediction_save_path, **predictions)


### PR DESCRIPTION
## Problem
The current code fails when trying to save predictions containing CUDA tensors using `np.savez()`, as numpy cannot directly serialize CUDA tensors.

## Solution
- Convert CUDA tensors to CPU before saving
- Handle both individual tensors and lists of tensors (like `pose_enc_list`)
- Maintain backward compatibility

## Testing
- [x] Verified fix works with CUDA tensors
- [x] Confirmed no regression with CPU-only tensors
- [x] Tested with existing model outputs

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)