### PR TITLE
Accelerate model loading on GPU by 1.24x

### DIFF
--- a/demo_colmap.py
+++ b/demo_colmap.py
@@ -110,12 +110,12 @@ def demo_fn(args):
     print(f"Using dtype: {dtype}")
 
     # Run VGGT for camera and depth estimation
-    model = VGGT()
+    model = VGGT().to(device)
     _URL = "https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
-    model.load_state_dict(torch.hub.load_state_dict_from_url(_URL))
+    state_dict = torch.hub.load_state_dict_from_url(_URL, map_location=device)
+    model.load_state_dict(state_dict)
     model.eval()
-    model = model.to(device)
-    print(f"Model loaded")
+    print(f"Model loaded to {device}")
 
     # Get image paths and preprocess them
     image_dir = os.path.join(args.scene_dir, "images")

--- a/demo_gradio.py
+++ b/demo_gradio.py
@@ -29,13 +29,12 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 print("Initializing and loading VGGT model...")
 # model = VGGT.from_pretrained("facebook/VGGT-1B")  # another way to load the model
 
-model = VGGT()
+model = VGGT().to(device)
 _URL = "https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
-model.load_state_dict(torch.hub.load_state_dict_from_url(_URL))
-
-
+state_dict = torch.hub.load_state_dict_from_url(_URL, map_location=device)
+model.load_state_dict(state_dict)
 model.eval()
-model = model.to(device)
+print(f"Model loaded to {device}")
 
 
 # -------------------------------------------------------------------------

--- a/demo_viser.py
+++ b/demo_viser.py
@@ -344,12 +344,12 @@ def main():
     print("Initializing and loading VGGT model...")
     # model = VGGT.from_pretrained("facebook/VGGT-1B")
 
-    model = VGGT()
+    model = VGGT().to(device)
     _URL = "https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
-    model.load_state_dict(torch.hub.load_state_dict_from_url(_URL))
-
+    state_dict = torch.hub.load_state_dict_from_url(_URL, map_location=device)
+    model.load_state_dict(state_dict)
     model.eval()
-    model = model.to(device)
+    print(f"Model loaded to {device}")
 
     # Use the provided image folder path
     print(f"Loading images from {args.image_folder}...")


### PR DESCRIPTION
# PR: Accelerate model loading by 1.24x

## Summary

This PR optimizes the model loading process, resulting in a **~1.24x speedup** on CUDA-enabled devices. The change is backward compatible.

Previously the model's weights were first loaded into CPU RAM and then copied in a large batch to the GPU via `model.to(device)`.
Now, an empty model "scaffold" is created directly in GPU VRAM. PyTorch reads the weights from disk and loads them directly into GPU VRAM.

```python
# Old method
model = VGGT()
model.load_state_dict(torch.hub.load_state_dict_from_url(url))
model = model.to(device)

# New method
model = VGGT().to(device)
model.load_state_dict(torch.hub.load_state_dict_from_url(url, map_location=device)) 
```

You can access the benchmarking script and results in [vggt_benchmark_loading.zip](https://github.com/user-attachments/files/21141674/vggt_benchmark_loading.zip). 

Thank you for the great work.
