### PR TITLE
Fix float32 auto-conversion

### DIFF
--- a/vggt/heads/dpt_head.py
+++ b/vggt/heads/dpt_head.py
@@ -256,7 +256,7 @@ class DPTHead(nn.Module):
         pos_embed = position_grid_to_embed(pos_embed, x.shape[1])
         pos_embed = pos_embed * ratio
         pos_embed = pos_embed.permute(2, 0, 1)[None].expand(x.shape[0], -1, -1, -1)
-        return x + pos_embed
+        return (x + pos_embed).to(x.dtype)
 
     def scratch_forward(self, features: List[torch.Tensor]) -> torch.Tensor:
         """

--- a/vggt/models/aggregator.py
+++ b/vggt/models/aggregator.py
@@ -204,8 +204,11 @@ class Aggregator(nn.Module):
         images = images.view(B * S, C_in, H, W)
         patch_tokens = self.patch_embed(images)
 
+        dtype = torch.bfloat16 if torch.cuda.get_device_capability()[0] >= 8 else torch.float16
         if isinstance(patch_tokens, dict):
-            patch_tokens = patch_tokens["x_norm_patchtokens"]
+            patch_tokens = patch_tokens["x_norm_patchtokens"].to(dtype)
+        else:
+            patch_tokens = patch_tokens.to(dtype)
 
         _, P, C = patch_tokens.shape
 


### PR DESCRIPTION
Fixes #39

On RTX 4090 GPU the model code auto-converted aggregated and patch tokens to torch.float32 dtype, even though bfloat16/float16 was specified. This lead to twice the amount of memory being used on the GPU. This fix prevents the auto-conversion providing memory performance as stated in the paper.