### PR TITLE
Fix: depth unprojection

### DIFF
--- a/training/data/dataset_util.py
+++ b/training/data/dataset_util.py
@@ -400,8 +400,8 @@ def depth_to_cam_coords_points(
     u, v = np.meshgrid(np.arange(W), np.arange(H))
     
     # Unproject to camera coordinates
-    x_cam = (u - cu) * depth_map / fu
-    y_cam = (v - cv) * depth_map / fv
+    x_cam = (u - cu + .5) * depth_map / fu
+    y_cam = (v - cv + .5) * depth_map / fv
     z_cam = depth_map
 
     # Stack to form camera coordinates

--- a/vggt/utils/geometry.py
+++ b/vggt/utils/geometry.py
@@ -107,8 +107,8 @@ def depth_to_cam_coords_points(depth_map: np.ndarray, intrinsic: np.ndarray) -> 
     u, v = np.meshgrid(np.arange(W), np.arange(H))
 
     # Unproject to camera coordinates
-    x_cam = (u - cu) * depth_map / fu
-    y_cam = (v - cv) * depth_map / fv
+    x_cam = (u - cu + .5) * depth_map / fu
+    y_cam = (v - cv + .5) * depth_map / fv
     z_cam = depth_map
 
     # Stack to form camera coordinates


### PR DESCRIPTION
Fixed missing half-pixel shift in depth unprojection functions. The PR addresses #354.

Why was it missing?

Let's consider a 518 px x 518 px image, with height and width H, W = 518, and principal point coordinates cx, cy = W/2, H/2 = 259. In the image coordinate system (x, y with 0,0 in the top-left corner), pixel cords range from 0 to 517.
The current implementation does not perform the half-pixel shift, so after transforming to the u, v coordinate system (centered at the principal point) by subtracting cx, cy, the new pixel coordinates range from -259 to 258. That means the top-left corner has u, v = (-259, -259) and the bottom-right corner = (258, 258).
For a pinhole camera, these should be symmetrical around zero. As a result, the rays used for depth unprojection are slightly off, producing incorrect 3D points.
Performing the half-pixel shift is standard practice to correct u, v to a symmetric range from -258.5 to 258.5.