### PR TITLE
Updates to track prediction (for demo_colmap.py)

### DIFF
--- a/vggt/dependency/track_predict.py
+++ b/vggt/dependency/track_predict.py
@@ -78,7 +78,7 @@ def predict_tracks(
 
     if fine_tracking:
         print("For faster inference, consider disabling fine_tracking")
-
+    
     for query_index in query_frame_indexes:
         print(f"Predicting tracks for query frame {query_index}")
         pred_track, pred_vis, pred_conf, pred_point_3d, pred_color = _forward_on_query(
@@ -301,7 +301,8 @@ def _augment_non_visible_frames(
         last_query = non_vis_frames[0]
 
         # Run the tracker for every selected frame
-        for query_index in query_frame_list:
+        for i, query_index in enumerate(query_frame_list):
+            print (f"Predicting tracks for query frame {query_index} (attempt {i+1})")
             new_track, new_vis, new_conf, new_point_3d, new_color = _forward_on_query(
                 query_index,
                 images,

--- a/vggt/dependency/vggsfm_utils.py
+++ b/vggt/dependency/vggsfm_utils.py
@@ -289,9 +289,9 @@ def predict_tracks_in_chunks(
         fine_pred_track, _, pred_vis, pred_score = track_predictor(
             images_feed, split_points, fmaps=fmaps_feed, fine_tracking=fine_tracking, fine_chunk=fine_chunk
         )
-        fine_pred_track_list.append(fine_pred_track)
-        pred_vis_list.append(pred_vis)
-        pred_score_list.append(pred_score)
+        fine_pred_track_list.append(fine_pred_track.detach() if fine_pred_track is not None else None)
+        pred_vis_list.append(pred_vis.detach() if pred_vis is not None else None)
+        pred_score_list.append(pred_score.detach() if pred_score is not None else None)
 
     # Concatenate the results from all splits
     fine_pred_track = torch.cat(fine_pred_track_list, dim=2)


### PR DESCRIPTION
Currently, predict_tracks_in_chunks doesn't detach tensors from GPU on each loop ([see here](https://github.com/facebookresearch/vggt/blob/44b3afbd1869d8bde4894dd8ea1e293112dd5eba/vggt/dependency/vggsfm_utils.py#L286-L295)). 

I think this is partially causing related memory issues with `demo_colmap.py` as reported in https://github.com/facebookresearch/vggt/issues/238. 

In addition, memory load seems to be most affected by max_points_num (dropping this number increases chunking and lowers memory load).