### PR TITLE
Inference on longer sequence without hurting performance

### DIFF
--- a/vggt/heads/dpt_head.py
+++ b/vggt/heads/dpt_head.py
@@ -49,7 +49,7 @@ class DPTHead(nn.Module):
         conf_activation: str = "expp1",
         features: int = 256,
         out_channels: List[int] = [256, 512, 1024, 1024],
-        intermediate_layer_idx: List[int] = [4, 11, 17, 23],
+        intermediate_layer_idx: List[int] = [0, 1, 2, 3],
         pos_embed: bool = True,
         feature_only: bool = False,
         down_ratio: int = 1,

--- a/vggt/models/aggregator.py
+++ b/vggt/models/aggregator.py
@@ -233,8 +233,9 @@ class Aggregator(nn.Module):
         frame_idx = 0
         global_idx = 0
         output_list = []
+        used_by_DPT_idx = [4, 11, 17, 23] 
 
-        for _ in range(self.aa_block_num):
+        for cur_block_num in range(self.aa_block_num):
             for attn_type in self.aa_order:
                 if attn_type == "frame":
                     tokens, frame_idx, frame_intermediates = self._process_frame_attention(
@@ -246,15 +247,18 @@ class Aggregator(nn.Module):
                     )
                 else:
                     raise ValueError(f"Unknown attention type: {attn_type}")
+                
+            # Only save the features that will be used by DPT heads, to save memory for both training and inference
+            if cur_block_num in used_by_DPT_idx:
+                for i in range(len(frame_intermediates)):
+                    # concat frame and global intermediates, [B x S x P x 2C]
+                    concat_inter = torch.cat([frame_intermediates[i], global_intermediates[i]], dim=-1)
+                    output_list.append(concat_inter)
+                    del concat_inter
 
-            for i in range(len(frame_intermediates)):
-                # concat frame and global intermediates, [B x S x P x 2C]
-                concat_inter = torch.cat([frame_intermediates[i], global_intermediates[i]], dim=-1)
-                output_list.append(concat_inter)
-
-        del concat_inter
         del frame_intermediates
         del global_intermediates
+
         return output_list, self.patch_start_idx
 
     def _process_frame_attention(self, tokens, B, S, P, C, frame_idx, pos=None):


### PR DESCRIPTION
Instead of saving features from all backbone layers, the updated code stores only the features required by the DPT heads. This reduces GPU memory usage during both training and inference without affecting performance.

With this change, the VGGT model can process around 1,000 images on a single 80GB GPU with no degradation in reconstruction quality.

This finding has also been adopted by other work like [Fast-VGGT](https://github.com/mystorm16/FastVGGT) and later [ZipMap](https://haian-jin.github.io/ZipMap/).