### PR TITLE
Fix out-of-range seq_index in VKittiDataset during eval

### DIFF
--- a/training/data/datasets/vkitti.py
+++ b/training/data/datasets/vkitti.py
@@ -107,7 +107,7 @@ class VKittiDataset(BaseDataset):
         Returns:
             dict: A batch of data including images, depths, and other metadata.
         """
-        if self.inside_random and self.training:
+        if self.inside_random:
             seq_index = random.randint(0, self.sequence_list_len - 1)
 
         if seq_name is None:


### PR DESCRIPTION
`VKittiDataset.get_data()` only resamples `seq_index` when `inside_random` and `self.training` are both true (vkitti.py:110). In eval mode (`training=False`), `seq_index` keeps whatever value the caller passed in, which can be a stale index from `ComposedDataset`'s upsampling remap and out of range for `sequence_list`. That's the out-of-range `seq_index` reported in #353 (values like 5053 and 53547, far past the actual number of VKitti sequences).

`co3d.py`'s `get_data()` does the same resampling without the training check (co3d.py:183). This drops the `and self.training` condition from vkitti.py so it matches that pattern.

Repro: built a `VKittiDataset` instance with 5 dummy sequences, `inside_random=True`, `training=False`, called `get_data(seq_index=9999)`.
- Before the fix: `IndexError: list index out of range`
- After the fix: `seq_index` gets resampled into `[0, 4]`, no error

This is a mocked instance-level repro, not a run against real VKitti data or a full training loop.